### PR TITLE
Add a basic test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: Test java2typescript
+
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v3
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    
+    - name: Setup Scala
+      uses: olafurpg/setup-scala@v11
+      with:
+        java-version: openjdk@1.17.0
+
+    - name: Build typescript writer
+      working-directory: ./src/main/javascript
+      run: npm install && npm run build
+    
+    - name: run test
+      run: sbt test


### PR DESCRIPTION
This adds a very basic CI workflow.

The command `sbt test` currently fails with

```
[…]
[info] *** 1 TEST FAILED ***
[error] Failed tests:
[error] 	de.terrestris.java2typescript.ClassSpec
[error] (Test / test) sbt.TestsFailedException: Tests unsuccessful
```

but this is the same behaviour I have locally, and the tested feature is not implemented yet.

Please review, @simonseyock 